### PR TITLE
Output error message raw to work around error

### DIFF
--- a/views/upload.njk
+++ b/views/upload.njk
@@ -28,11 +28,7 @@
   <div class="alert alert-danger" role="alert">
     <strong>Your GeoJSON file "{{ file }}" is not valid.</strong>
     <p>Here is why :</p>
-    <ul>
-    {% for error in errors %}
-      <li>{{ error.message }}</li>
-    {% endfor %}
-    </ul>
+    <pre>{{ errors | dump | safe }}</pre>
   </div>
   {% else %}
     {% if file %}


### PR DESCRIPTION
This is less nice looking, but it prevents the following error message.

<img width="850" alt="Bildschirmfoto 2020-08-12 um 22 14 36" src="https://user-images.githubusercontent.com/111561/90063409-a27fda00-dce9-11ea-88d5-8f346d5b7936.png">


```
(/Users/…/views/upload.njk) [Line 33, Column 11] attempted to output null or undefined value
Template render error: (/Users/…/views/upload.njk) [Line 33, Column 11]
  attempted to output null or undefined value
    at Object._prettifyError (/Users/…/node_modules/nunjucks/src/lib.js:36:11)
    at /Users/…/node_modules/nunjucks/src/environment.js:561:19
    at eval (eval at _compile (/Users/…/node_modules/nunjucks/src/environment.js:631:18), <anonymous>:25:11)
    at b_content (eval at _compile (/Users/…/node_modules/nunjucks/src/environment.js:631:18), <anonymous>:123:3)
    at eval (eval at _compile (/Users/…/node_modules/nunjucks/src/environment.js:631:18), <anonymous>:24:86)
    at b_stylesheets (eval at _compile (/Users/…/node_modules/nunjucks/src/environment.js:631:18), <anonymous>:44:1)
    at Template.root [as rootRenderFunc] (eval at _compile (/Users/…/node_modules/nunjucks/src/environment.js:631:18), <anonymous>:20:90)
    at eval (eval at _compile (/Users/…/node_modules/nunjucks/src/environment.js:631:18), <anonymous>:28:16)
    at eval (eval at _compile (/Users/…/node_modules/nunjucks/src/environment.js:631:18), <anonymous>:23:46)
    at eval (eval at _compile (/Users/…/node_modules/nunjucks/src/environment.js:631:18), <anonymous>:23:86)
```

With the file https://www.giessdenkiez.de/data/pumps.geojson